### PR TITLE
Update index.astro

### DIFF
--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -1,46 +1,40 @@
 ---
+import { joinURL } from "ufo";
+
 import Layout from "../layouts/Layout.astro";
 import { getLatestRelease } from "../lib/github";
 
+import { name } from "../../../buildspec.json";
+const githubURL = `https://github.com/kaito-tokyo/${name}`;
+
 const release = await getLatestRelease();
 const tagName = release.tag_name;
-
-// Find asset download URLs by matching asset names
-const windowsAsset = release.assets.find(
-  (asset) => asset.name.includes("windows") && asset.name.endsWith(".zip"),
-);
-const macAsset = release.assets.find(
-  (asset) =>
-    asset.name.includes("mac") &&
-    (asset.name.endsWith(".pkg") || asset.name.endsWith(".dmg")),
-);
-const ubuntuAsset = release.assets.find(
-  (asset) =>
-    asset.name.includes("linux") &&
-    (asset.name.endsWith(".deb") || asset.name.endsWith(".AppImage")),
-);
 ---
 
-<Layout title="Live Background Removal Lite" lang="ja">
-  <h1>ライブUNITEツール</h1>
+<Layout title="Live Unite Tools" lang="en">
+  <h1>Live Unite Tools</h1>
   <div class="links">
     <a
-      href={windowsAsset ? windowsAsset.browser_download_url : "#"}
-      aria-disabled={!windowsAsset}
-      >Windows{!windowsAsset ? " (Not available)" : ""}</a
+      href={joinURL(
+        githubURL,
+        `releases/download/${tagName}/${name}-${tagName}-windows-x64.zip`,
+      )}>Windows</a
     >
     <a
-      href={macAsset ? macAsset.browser_download_url : "#"}
-      aria-disabled={!macAsset}>Mac{!macAsset ? " (Not available)" : ""}</a
+      href={joinURL(
+        githubURL,
+        `releases/download/${tagName}/${name}-${tagName}-macos-universal.pkg`,
+      )}>Mac</a
     >
     <a
-      href={ubuntuAsset ? ubuntuAsset.browser_download_url : "#"}
-      aria-disabled={!ubuntuAsset}
-      >Ubuntu{!ubuntuAsset ? " (Not available)" : ""}</a
+      href={joinURL(
+        githubURL,
+        `releases/download/${tagName}/${name}-${tagName}-x86_64-linux-gnu.deb`,
+      )}>Ubuntu</a
     >
   </div>
   <div class="links">
-    <a href="https://github.com/kaito-tokyo/live-unite-tools/">GitHub</a>
+    <a href={githubURL}>GitHub</a>
   </div>
 </Layout>
 


### PR DESCRIPTION
This pull request updates the main documentation page to simplify and standardize how download links for different platforms are generated. Instead of dynamically searching for release assets, it now constructs the download URLs directly, making the code easier to maintain and less error-prone. The page title and language have also been updated for consistency.

Download link generation improvements:

* Replaced asset search logic with direct URL construction for Windows, Mac, and Ubuntu downloads using the latest release tag and project name. This ensures the links are always present and correctly formatted.
* Introduced `joinURL` from the `ufo` package to safely build URLs for downloads and the GitHub project.

Documentation and UI updates:

* Updated the page title and heading from Japanese to English, and changed the language attribute to `en` for consistency.
* Updated the GitHub link to use the dynamically constructed project URL.