### PR TITLE
Update workflow triggers and deployment conditions

### DIFF
--- a/.github/workflows/my-astro.yml
+++ b/.github/workflows/my-astro.yml
@@ -1,6 +1,9 @@
 name: Deploy Astro site to Pages
 
 on:
+  pull_request:
+    branches:
+      - "main"
   push:
     branches:
       - "main"
@@ -72,6 +75,7 @@ jobs:
       url: "${{ steps.deployment.outputs.page_url }}"
     needs: "build"
     runs-on: "ubuntu-24.04"
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     name: "Deploy"
     steps:
       - name: "Deploy to GitHub Pages"

--- a/.github/workflows/pr-pull.yaml
+++ b/.github/workflows/pr-pull.yaml
@@ -3,7 +3,7 @@ run-name: ${{ github.event.pull_request.title }} pull request run 🚀
 on:
   workflow_dispatch:
   pull_request:
-    paths-ignore:
+#    paths-ignore:
 #      - '**.md'
     branches: [master, main]
     types: [ opened, synchronize, reopened ]


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve deployment control and pull request handling. The main changes focus on ensuring deployments only run under the correct conditions and making it easier to test workflow changes on pull requests.

**Workflow configuration improvements:**

* Added a `pull_request` trigger to `.github/workflows/my-astro.yml` for the `main` branch, allowing workflow runs on pull requests targeting `main`.
* Updated the deployment job in `.github/workflows/my-astro.yml` to run only for pushes to `main` or tags, preventing deployments on other branches or pull requests.

**Pull request workflow adjustments:**

* Commented out the `paths-ignore` filter in `.github/workflows/pr-pull.yaml` to allow the workflow to run on all file changes, making it easier to test workflow changes during pull requests.Added pull_request trigger for main branch in my-astro.yml and restricted deployment to main branch or tags. Uncommented paths-ignore in pr-pull.yaml to allow workflow to run on all file changes.