### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,36 @@
-# OBS Plugin Template
+# Live Unite Tools
 
-## Introduction
+[**⬇️ Download Latest Release**](https://kaito-tokyo.github.io/live-unite-tools/)
 
-The plugin template is meant to be used as a starting point for OBS Studio plugin development. It includes:
+---
 
-* Boilerplate plugin source code
-* A CMake project file
-* GitHub Actions workflows and repository actions
+## 💻 Installation
 
-## Supported Build Environments
+1.  Go to the [Releases page](https://live-backgroundremoval-lite.kaito.tokyo/) and download the appropriate file for your operating system.
 
-| Platform  | Tool   |
-|-----------|--------|
-| Windows   | Visal Studio 17 2022 |
-| macOS     | XCode 16.0 |
-| Windows, macOS  | CMake 3.30.5 |
-| Ubuntu 24.04 | CMake 3.28.3 |
-| Ubuntu 24.04 | `ninja-build` |
-| Ubuntu 24.04 | `pkg-config`
-| Ubuntu 24.04 | `build-essential` |
+2.  Follow the instructions for your OS:
+    * **For Windows:**
+        * Download the `.zip` file and extract its contents into your OBS Studio installation directory (e.g., `C:\Program Files\obs-studio`).
+    * **For macOS:**
+        * Download and run the `.pkg` installer.
 
-## Quick Start
+3.  Restart OBS Studio after the installation is complete.
 
-An absolute bare-bones [Quick Start Guide](https://github.com/obsproject/obs-plugintemplate/wiki/Quick-Start-Guide) is available in the wiki.
+## 🙏 Acknowledgements
 
-## Documentation
+This project is built upon and incorporates several open-source components. We are grateful to the developers and contributors of these projects.
 
-All documentation can be found in the [Plugin Template Wiki](https://github.com/obsproject/obs-plugintemplate/wiki).
+<details>
+<summary>List of Open Source Components</summary>
 
-Suggested reading to get up and running:
+* **OBS Studio**
+    * License: [GPL-2.0-or-later](https://github.com/obsproject/obs-studio/blob/master/COPYING)
+</details>
 
-* [Getting started](https://github.com/obsproject/obs-plugintemplate/wiki/Getting-Started)
-* [Build system requirements](https://github.com/obsproject/obs-plugintemplate/wiki/Build-System-Requirements)
-* [Build system options](https://github.com/obsproject/obs-plugintemplate/wiki/CMake-Build-System-Options)
+## 🐞 Bug Reports
 
-## GitHub Actions & CI
+If you find a bug or issue, please report it on the [GitHub Issues page](https://github.com/kaito-tokyo/live-unite-tools/issues).
 
-Default GitHub Actions workflows are available for the following repository actions:
+## 📜 License
 
-* `push`: Run for commits or tags pushed to `master` or `main` branches.
-* `pr-pull`: Run when a Pull Request has been pushed or synchronized.
-* `dispatch`: Run when triggered by the workflow dispatch in GitHub's user interface.
-* `build-project`: Builds the actual project and is triggered by other workflows.
-* `check-format`: Checks CMake and plugin source code formatting and is triggered by other workflows.
-
-The workflows make use of GitHub repository actions (contained in `.github/actions`) and build scripts (contained in `.github/scripts`) which are not needed for local development, but might need to be adjusted if additional/different steps are required to build the plugin.
-
-### Retrieving build artifacts
-
-Successful builds on GitHub Actions will produce build artifacts that can be downloaded for testing. These artifacts are commonly simple archives and will not contain package installers or installation programs.
-
-### Building a Release
-
-To create a release, an appropriately named tag needs to be pushed to the `main`/`master` branch using semantic versioning (e.g., `12.3.4`, `23.4.5-beta2`). A draft release will be created on the associated repository with generated installer packages or installation programs attached as release artifacts.
-
-## Signing and Notarizing on macOS
-
-Basic concepts of codesigning and notarization on macOS are explained in the correspodning [Wiki article](https://github.com/obsproject/obs-plugintemplate/wiki/Codesigning-On-macOS) which has a specific section for the [GitHub Actions setup](https://github.com/obsproject/obs-plugintemplate/wiki/Codesigning-On-macOS#setting-up-code-signing-for-github-actions).
+This plugin itself is licensed under the [GPL-3.0-or-later](LICENSE).


### PR DESCRIPTION
This pull request updates the `README.md` file to provide new installation instructions and project information, replacing the previous OBS plugin template documentation. The changes focus on making it easier for users to install the plugin, understand its dependencies, and report issues.

Documentation and installation improvements:

* Updated the project title and introduction to reflect the new name `Live Unite Tools` and added a prominent download link for the latest release.
* Added clear, step-by-step installation instructions for both Windows and macOS users.

Project information and support:

* Included an acknowledgements section listing open-source components used, with licensing details for `OBS Studio`.
* Provided instructions for reporting bugs via the GitHub Issues page.
* Specified the plugin's license as `GPL-3.0-or-later`.